### PR TITLE
Pin Celery version in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-celery
+celery<5.0.0
 flower
 redis


### PR DESCRIPTION
Got this error when trying to run with celery 5+
```
ImportError: cannot import name 'Command' from 'celery.bin.base' (/Users/eligothill/simple-celery-flower-on-heroku/env/lib/python3.7/site-packages/celery/bin/base.py)
```
Downgrading to celery 4 worked